### PR TITLE
Update DescriptorWriter.java

### DIFF
--- a/java/org/l2jmobius/xml/DescriptorWriter.java
+++ b/java/org/l2jmobius/xml/DescriptorWriter.java
@@ -395,7 +395,7 @@ public class DescriptorWriter
 				case UINT:
 				case INT:
 				{
-					return ByteWriter.writeInt(Integer.parseInt(data));
+					return ByteWriter.writeInt(Integer.parseInt(data.trim()));
 				}
 				case UNICODE:
 				{


### PR DESCRIPTION
Fixing issue when packing files like:
GameDataBase-eu.txt

Issue from this line:
node_begin	name=[Ability]	type=5

because type is read with new line - it causes issues. No impact on other files and if you expect INT/UINT - they should be trimmed anyway.